### PR TITLE
Remote PDB support + rpdb dual-session debugger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ wheels/
 
 # Lock files (generated from pyproject.toml)
 uv.lock
+
+# Local CE review artifacts
+.context/

--- a/README.md
+++ b/README.md
@@ -62,17 +62,77 @@ Connect to a Python process that exposes PDB over a TCP socket.  All existing
 tools (`send_pdb_command`, `set_breakpoint`, `examine_variable`, etc.) work
 identically once connected.
 
-### Setup on the remote side
+### rpdb — dual-session debugger (recommended)
 
-**Option A – `remote-pdb` package (recommended)**
+`rpdb` is installed alongside `mcp-pdb` and is the easiest way to debug with
+both a local terminal and the MCP agent simultaneously.
+
+```
+Terminal ──→ stdin ──→ PDB ──→ stdout ──→ Terminal
+                            └──→ socket ──→ mcp-pdb
+mcp-pdb  ──→ socket ──┘  (local stdin takes priority)
+```
+
+**Start a script under rpdb:**
+
+```bash
+REMOTE_PDB_PORT=4444 rpdb script.py [args]
+REMOTE_PDB_PORT=4444 rpdb -m mymodule [args]
+```
+
+rpdb prints `waiting for mcp connection on 127.0.0.1:4444 ...` and blocks
+until the MCP agent connects.  All normal pdb flags (`-c`, `--help`, etc.)
+are supported.
+
+**Then connect from Claude / the MCP agent:**
+
+```
+connect_remote_debug(host="127.0.0.1", port=4444)
+```
+
+All PDB output is now mirrored to both the terminal and the agent.  Commands
+typed in the terminal take priority; the agent's commands are echoed to the
+terminal so you can follow along.
+
+**Environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REMOTE_PDB_HOST` | `127.0.0.1` | Interface to listen on (`0.0.0.0` for remote machines) |
+| `REMOTE_PDB_PORT` | `4444` | TCP port |
+
+**In-source one-liner** (correct frame, all locals visible):
 
 ```python
-# In your Python script or inside a debugger trigger:
+# Add at the line you want to break at:
+from mcp_pdb.rpdb import set_trace; set_trace()
+```
+
+The process blocks here until the MCP agent (or any TCP client) connects.
+
+**Zero-code-change with `breakpoint()`:**
+
+```bash
+PYTHONBREAKPOINT=mcp_pdb.rpdb.set_trace python script.py
+```
+
+**Python ≥ 3.11 with `--pdbcls`** (remote only, no local terminal):
+
+```bash
+python -m pdb --pdbcls=mcp_pdb.rpdb:Debugger script.py
+pytest --pdb --pdbcls=mcp_pdb.rpdb:Debugger
+```
+
+### Manual remote-pdb setup
+
+If you need to attach to an already-running process without using `rpdb`:
+
+**Option A – `remote-pdb` package**
+
+```python
 from remote_pdb import RemotePdb
 RemotePdb("0.0.0.0", 4444).set_trace()
 ```
-
-Install once: `pip install remote-pdb`
 
 **Option B – stdlib only**
 
@@ -88,7 +148,7 @@ f = conn.makefile("rwb", buffering=0)
 pdb.Pdb(stdin=io.TextIOWrapper(f), stdout=io.TextIOWrapper(f)).set_trace()
 ```
 
-### Connect from Claude / the LLM
+**Connect from Claude / the LLM:**
 
 ```
 connect_remote_debug(host="192.168.1.10", port=4444)

--- a/README.md
+++ b/README.md
@@ -45,15 +45,60 @@ claude mcp add mcp-pdb -- uv run --python 3.13 --with mcp-pdb mcp-pdb
 
 | Tool | Description |
 |------|-------------|
-| `start_debug(file_path, use_pytest, args)` | Start a debugging session for a Python file |
-| `send_pdb_command(command)` | Send a command to the running PDB instance |
+| `start_debug(file_path, use_pytest, args)` | Start a local debugging session for a Python file |
+| `connect_remote_debug(host, port, timeout)` | Connect to a remote PDB session over TCP |
+| `send_pdb_command(command)` | Send a command to the running PDB instance (local or remote) |
 | `set_breakpoint(file_path, line_number)` | Set a breakpoint at a specific line |
 | `clear_breakpoint(file_path, line_number)` | Clear a breakpoint at a specific line |
 | `list_breakpoints()` | List all current breakpoints |
-| `restart_debug()` | Restart the current debugging session |
+| `restart_debug()` | Restart/reconnect the current debugging session |
 | `examine_variable(variable_name)` | Get detailed information about a variable |
 | `get_debug_status()` | Show the current state of the debugging session |
-| `end_debug()` | End the current debugging session |
+| `end_debug()` | End the current debugging session (closes socket for remote) |
+
+## Remote Debugging
+
+Connect to a Python process that exposes PDB over a TCP socket.  All existing
+tools (`send_pdb_command`, `set_breakpoint`, `examine_variable`, etc.) work
+identically once connected.
+
+### Setup on the remote side
+
+**Option A – `remote-pdb` package (recommended)**
+
+```python
+# In your Python script or inside a debugger trigger:
+from remote_pdb import RemotePdb
+RemotePdb("0.0.0.0", 4444).set_trace()
+```
+
+Install once: `pip install remote-pdb`
+
+**Option B – stdlib only**
+
+```python
+import io, socket, pdb
+
+srv = socket.socket()
+srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+srv.bind(("0.0.0.0", 4444))
+srv.listen(1)
+conn, _ = srv.accept()   # blocks until MCP connects
+f = conn.makefile("rwb", buffering=0)
+pdb.Pdb(stdin=io.TextIOWrapper(f), stdout=io.TextIOWrapper(f)).set_trace()
+```
+
+### Connect from Claude / the LLM
+
+```
+connect_remote_debug(host="192.168.1.10", port=4444)
+```
+
+`timeout` (default 30 s) controls how long to retry on `ConnectionRefused`—
+useful when the remote process has not yet reached `set_trace()`.
+
+`restart_debug()` reconnects to the same host/port.  `end_debug()` closes the
+socket gracefully (sends `q` first).
 
 ## Common PDB Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "samefarrar", email = "67292186+samefarrar@users.noreply.github.com" },
 ]
 requires-python = ">=3.10"
-dependencies = ["mcp[cli]>=1.6.0"]
+dependencies = ["mcp[cli]>=1.6.0", "remote-pdb>=2.1.0"]
 license = { text = "MIT" }
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -17,6 +17,7 @@ classifiers = [
 
 [project.scripts]
 mcp-pdb = "mcp_pdb:main"
+rpdb = "mcp_pdb.rpdb:main"
 
 [dependency-groups]
 dev = ["pytest>=8.0.0"]

--- a/src/mcp_pdb/main.py
+++ b/src/mcp_pdb/main.py
@@ -32,7 +32,6 @@ caveman_mode = False          # When True: compact output; False (default): full
 
 # Remote PDB session state
 remote_socket = None          # Connected socket for remote PDB
-remote_socket_file = None     # Binary file wrapper used by the reader thread
 remote_mode = False           # True when connected to a remote PDB session
 remote_host = ""              # Remote hostname/IP
 remote_port = 0               # Remote TCP port
@@ -84,10 +83,14 @@ def read_socket_output(sock: socket_module.socket, output_queue: queue.Queue) ->
                 break
             buf += chunk
 
-            # Emit all newline-terminated lines
+            # Emit all newline-terminated lines.  Strip only '\r' so that
+            # intentional trailing whitespace inside variable reprs (e.g.
+            # "'hello   '") is preserved.
             while b"\n" in buf:
                 line, buf = buf.split(b"\n", 1)
-                output_queue.put(line.decode("utf-8", errors="replace").rstrip())
+                output_queue.put(
+                    line.decode("utf-8", errors="replace").rstrip("\r")
+                )
 
             # If residual bytes remain (no \n), check whether more data is
             # arriving within 50 ms.  If not, emit them now — they are almost
@@ -95,13 +98,17 @@ def read_socket_output(sock: socket_module.socket, output_queue: queue.Queue) ->
             if buf:
                 r, _, _ = select.select([sock], [], [], 0.05)
                 if not r:
-                    output_queue.put(buf.decode("utf-8", errors="replace").rstrip())
+                    output_queue.put(
+                        buf.decode("utf-8", errors="replace").rstrip("\r")
+                    )
                     buf = b""
     except Exception as e:
         print(f"Remote PDB reader: unexpected error: {e}", file=sys.stderr)
     finally:
         if buf:
-            output_queue.put(buf.decode("utf-8", errors="replace").rstrip())
+            output_queue.put(
+                buf.decode("utf-8", errors="replace").rstrip("\r")
+            )
         print("Remote PDB output reader thread finished.", file=sys.stderr)
 
 
@@ -139,14 +146,35 @@ def get_pdb_output(timeout=0.5):
     return '\n'.join(cleaned)
 
 
-def _is_local_process_alive():
+def _is_local_process_alive() -> bool:
     """Return True if the local PDB subprocess is still running."""
     return pdb_process is not None and pdb_process.poll() is None
 
 
-def _is_remote_connected():
-    """Return True if the remote socket is still open."""
+def _is_remote_connected() -> bool:
+    """Return True if the remote socket reference is still set.
+
+    Note: this checks object identity, not socket liveness — a socket that
+    was closed by the peer will still pass this check until cleanup runs.
+    """
     return remote_socket is not None
+
+
+def _clear_remote_state() -> None:
+    """Reset every remote_* global to the idle default.
+
+    Every cleanup path MUST call this instead of touching the globals
+    individually.  The invariant is: if ``remote_socket is None`` then
+    ``remote_mode is False`` and host/port are empty — there is no valid
+    intermediate state.  Prior to this helper, partial resets left
+    ``remote_mode=True`` after error paths which corrupted ``restart_debug``
+    and ``get_debug_status``.
+    """
+    global remote_socket, remote_mode, remote_host, remote_port
+    remote_socket = None
+    remote_mode = False
+    remote_host = ""
+    remote_port = 0
 
 
 def send_to_pdb(command, timeout_multiplier=1.0):
@@ -160,26 +188,36 @@ def send_to_pdb(command, timeout_multiplier=1.0):
         command: The PDB command to send
         timeout_multiplier: Multiplier to adjust timeout for complex commands
     """
-    global pdb_process, pdb_running, remote_socket, remote_mode
+    # pdb_running is the only global mutated here; others are read-only
+    # (remote_socket / remote_mode are cleared via _clear_remote_state).
+    global pdb_running
 
-    # Resolve and type-narrow the active transport before any I/O.
-    # Using local variables lets Pyright track non-None invariants.
+    # Resolve and type-narrow the active transport before any I/O by binding
+    # to local variables.  Local rebind survives -O (assert is stripped).
+    rsock: socket_module.socket | None = None
+    lproc: subprocess.Popen | None = None
     if remote_mode:
-        if remote_socket is None:
+        rsock = remote_socket
+        if rsock is None:
             if pdb_running:
                 pdb_running = False
                 final_output = get_pdb_output(timeout=0.1)
-                return f"No active remote pdb connection.\nFinal Output:\n{final_output}"
+                return (
+                    "No active remote pdb connection.\n"
+                    f"Final Output:\n{final_output}"
+                )
             return "No active remote pdb connection."
-        pass  # remote_socket is non-None; accessed via assert below
     else:
-        if pdb_process is None or pdb_process.poll() is not None:
+        lproc = pdb_process
+        if lproc is None or lproc.poll() is not None:
             if pdb_running:
                 pdb_running = False
                 final_output = get_pdb_output(timeout=0.1)
-                return f"No active pdb process (it terminated).\nFinal Output:\n{final_output}"
+                return (
+                    "No active pdb process (it terminated).\n"
+                    f"Final Output:\n{final_output}"
+                )
             return "No active pdb process."
-        # pdb_process is non-None; accessed via assert below
 
     # Clear queue before sending command to get only relevant output
     while not pdb_output_queue.empty():
@@ -194,15 +232,12 @@ def send_to_pdb(command, timeout_multiplier=1.0):
         else:
             timeout = base_timeout * timeout_multiplier
 
-        if remote_mode:
+        if rsock is not None:
             # TCP socket: sendall is synchronous, no flush needed.
-            # remote_socket is non-None: checked and returned early above.
-            assert remote_socket is not None
-            remote_socket.sendall((command + '\n').encode('utf-8'))
+            rsock.sendall((command + '\n').encode('utf-8'))
         else:
-            # pdb_process is non-None: checked and returned early above.
-            assert pdb_process is not None
-            stdin = pdb_process.stdin
+            assert lproc is not None  # narrowed above; here for the type checker
+            stdin = lproc.stdin
             if stdin is None:
                 return "Error: PDB process stdin is not available."
             stdin.write((command + '\n').encode('utf-8'))
@@ -211,11 +246,13 @@ def send_to_pdb(command, timeout_multiplier=1.0):
         output = get_pdb_output(timeout=timeout)
 
         # For local sessions, check if process ended after the command
-        if not remote_mode and pdb_process is not None and pdb_process.poll() is not None:
+        if lproc is not None and lproc.poll() is not None:
             pdb_running = False
             final_output = get_pdb_output(timeout=0.1)
-            return (f"Command output:\n{output}\n{final_output}\n\n"
-                    "*** The debugging session has ended. ***")
+            return (
+                f"Command output:\n{output}\n{final_output}\n\n"
+                "*** The debugging session has ended. ***"
+            )
 
         return output
 
@@ -223,24 +260,40 @@ def send_to_pdb(command, timeout_multiplier=1.0):
         print(f"Error writing to PDB: {e}", file=sys.stderr)
         pdb_running = False
         final_output = get_pdb_output(timeout=0.1)
-        if not remote_mode:
-            if pdb_process:
-                pdb_process.terminate()
-                pdb_process.wait(timeout=0.5)
-        else:
-            rsock = remote_socket
-            if rsock is not None:
-                try:
-                    rsock.close()
-                except Exception:
-                    pass
-            remote_socket = None
+        if rsock is not None:
+            # Remote transport is dead; fully clear remote state so
+            # restart_debug/get_debug_status do not observe a zombie
+            # (remote_mode=True, remote_socket=None) half-state.
+            try:
+                rsock.shutdown(socket_module.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                rsock.close()
+            except OSError:
+                pass
+            _clear_remote_state()
+        elif pdb_process:
+            pdb_process.terminate()
+            pdb_process.wait(timeout=0.5)
         return (f"Error communicating with PDB: {e}\n"
                 f"Final Output:\n{final_output}\n\n"
                 "*** The debugging session has likely ended. ***")
     except Exception as e:
         print(f"Unexpected error in send_to_pdb: {e}", file=sys.stderr)
         pdb_running = False
+        if rsock is not None:
+            # Match the OSError path: shutdown() before close() so the
+            # reader thread unblocks from recv()/select() immediately.
+            try:
+                rsock.shutdown(socket_module.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                rsock.close()
+            except OSError:
+                pass
+            _clear_remote_state()
         return f"Unexpected error sending command: {e}"
 
 
@@ -369,40 +422,47 @@ def connect_remote_debug(host: str = "localhost", port: int = 4444,
                           timeout: int = 30, caveman_mode: bool = False) -> str:
     """Connect to a remote PDB session listening on a TCP socket.
 
-    The remote Python process must expose PDB over a network socket, for example
-    using the `remote-pdb` package:
+    Success is defined as "TCP connection established".  The tool does NOT
+    wait for an initial ``(Pdb)`` prompt because the primary use case —
+    attaching via ``rpdb`` to a script that has not yet reached a
+    breakpoint — has no prompt to wait for.  Any output already buffered on
+    the socket is best-effort drained over ~100 ms and returned.  Once the
+    remote process reaches a prompt, subsequent ``send_pdb_command`` calls
+    work normally; commands sent before that point queue on the socket and
+    are consumed by PDB when it starts reading.
 
-        from remote_pdb import RemotePdb
-        RemotePdb('0.0.0.0', 4444).set_trace()
-
-    Or with a custom setup:
-
-        import pdb, socket, io
-        s = socket.socket(); s.bind(('0.0.0.0', 4444)); s.listen(1)
-        conn, _ = s.accept()
-        f = conn.makefile('rwb', buffering=0)
-        pdb.Pdb(stdin=io.TextIOWrapper(f), stdout=io.TextIOWrapper(f)).set_trace()
-
-    Once connected all existing tools (send_pdb_command, set_breakpoint, etc.)
-    work exactly the same as for a local session.
+    Works with both:
+    - ``rpdb script.py`` (DualPdb accepts the socket **before** starting
+      the script — no prompt exists until a breakpoint fires)
+    - ``remote_pdb.RemotePdb().set_trace()`` (process is already paused —
+      the prompt is usually immediately available)
 
     Args:
         host:    Hostname or IP address of the remote machine (default "localhost").
         port:    TCP port the remote PDB is listening on (default 4444).
-        timeout: Seconds to wait for a successful connection, retrying on
+        timeout: Seconds to wait for a successful TCP connection, retrying on
                  ConnectionRefused (default 30).  Set to 0 for a single attempt.
+        caveman_mode: Opt-in compact output mode (default False).  When True:
+                 skips the 11-line source window after navigation, omits dir()
+                 in examine_variable unless include_attrs=True, and strips bare
+                 (Pdb) prompts.  Use to reduce token usage when the agent
+                 doesn't need the full context.
     """
     globals()['caveman_mode'] = caveman_mode  # set module-level flag from param
-    global pdb_running, remote_socket, remote_socket_file, remote_mode
+    global pdb_running, remote_socket, remote_mode
     global remote_host, remote_port, output_thread, pdb_output_queue
 
     if pdb_running:
         if remote_mode:
-            return (f"Already connected to remote PDB at {remote_host}:{remote_port}. "
-                    "Use end_debug first.")
+            return (
+                f"Already connected to remote PDB at "
+                f"{remote_host}:{remote_port}. Use end_debug first."
+            )
         else:
-            return (f"Local debugging session already running for {current_file}. "
-                    "Use end_debug first.")
+            return (
+                f"Local debugging session already running for "
+                f"{current_file}. Use end_debug first."
+            )
 
     # Clear the output queue
     while not pdb_output_queue.empty():
@@ -413,12 +473,13 @@ def connect_remote_debug(host: str = "localhost", port: int = 4444,
     deadline = time.monotonic() + max(timeout, 0)
     last_error = None
     sock = None
-    first_attempt = True
 
     print(f"Connecting to remote PDB at {host}:{port} (timeout={timeout}s)...")
     while True:
         try:
-            sock = socket_module.socket(socket_module.AF_INET, socket_module.SOCK_STREAM)
+            sock = socket_module.socket(
+                socket_module.AF_INET, socket_module.SOCK_STREAM
+            )
             sock.settimeout(5.0)
             sock.connect((host, port))
             sock.settimeout(None)  # Switch to blocking after connect
@@ -430,56 +491,84 @@ def connect_remote_debug(host: str = "localhost", port: int = 4444,
                 try: sock.close()
                 except Exception: pass
                 sock = None
-            remaining = deadline - time.monotonic()
-            if remaining <= 0 or (first_attempt and timeout == 0):
+            if timeout == 0:
                 break
-            print(f"Connection refused ({e}), retrying... ({remaining:.1f}s remaining)")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            print(
+                f"Connection refused ({e}), retrying... "
+                f"({remaining:.1f}s remaining)"
+            )
             time.sleep(min(1.0, remaining))
-        first_attempt = False
 
     if sock is None:
-        return (f"Failed to connect to {host}:{port} within {timeout}s. "
-                f"Last error: {last_error}")
+        return (
+            f"Failed to connect to {host}:{port} within {timeout}s. "
+            f"Last error: {last_error}"
+        )
+
+    # Spawn the reader thread BEFORE we commit any state so that any
+    # exception during setup can tear down cleanly without leaving a
+    # half-initialized session visible to other tools.
+    if output_thread and output_thread.is_alive():
+        print("Warning: Previous output thread was still alive.", file=sys.stderr)
+
+    t = threading.Thread(
+        target=read_socket_output,
+        args=(sock, pdb_output_queue),
+        daemon=True,
+    )
 
     try:
-        # Ensure previous output thread is not hanging around
-        if output_thread and output_thread.is_alive():
-            print("Warning: Previous output thread was still alive.", file=sys.stderr)
-
-        # Pass the raw socket — read_socket_output uses recv()+select()
-        # so it can emit the (Pdb) prompt that has no trailing newline.
-        t = threading.Thread(
-            target=read_socket_output,
-            args=(sock, pdb_output_queue),
-            daemon=True,
-        )
         t.start()
-        output_thread = t
 
-        # Wait for the initial (Pdb) prompt from the remote side
-        print("Waiting for remote PDB prompt...")
-        initial_output = get_pdb_output(timeout=5.0)
+        # Best-effort drain: if the remote side is already at a prompt
+        # (e.g. RemotePdb.set_trace()) whatever is buffered arrives in
+        # <100 ms.  A missing prompt is NOT an error — for DualPdb/rpdb
+        # it is the normal case because the script has not started yet.
+        initial_output = get_pdb_output(timeout=0.1)
 
-        if not initial_output.strip():
-            initial_output = ("(No initial output received yet. "
-                              "The remote process may be waiting for execution to reach "
-                              "the set_trace() call, or it is already at a prompt.)")
-
-        # Commit remote state
+        # Commit remote state atomically.  pdb_running is set LAST so
+        # any tool guarding on it either sees a fully-configured session
+        # or no session at all — never a partial one.
         remote_socket = sock
-        remote_socket_file = None  # raw socket used directly; no file wrapper
         remote_mode = True
         remote_host = host
         remote_port = port
+        output_thread = t
         pdb_running = True
 
-        return (f"Connected to remote PDB at {host}:{port}\n\n"
-                f"Initial output:\n{initial_output}")
-
     except Exception as e:
-        try: sock.close()
-        except Exception: pass
-        return f"Error setting up remote connection: {e}\n{traceback.format_exc()}"
+        # Tear down the reader thread and socket.  We deliberately do NOT
+        # call _clear_remote_state() here — none of the remote_* globals
+        # were committed yet (the commit block above raised before
+        # finishing), so there is nothing to clear.  The module stays in
+        # its pre-call idle state and the caller sees a plain error.
+        try:
+            sock.shutdown(socket_module.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            sock.close()
+        except OSError:
+            pass
+        return (
+            f"Error setting up remote connection: {e}\n"
+            f"{traceback.format_exc()}"
+        )
+
+    if initial_output.strip():
+        return (
+            f"Connected to remote PDB at {host}:{port}\n\n"
+            f"Initial output:\n{initial_output}"
+        )
+    return (
+        f"Connected to remote PDB at {host}:{port}\n\n"
+        "(No prompt yet — the remote process has not reached a breakpoint. "
+        "Commands sent via send_pdb_command will queue on the socket and "
+        "be processed when PDB starts reading.)"
+    )
 
 
 @mcp.tool()
@@ -491,9 +580,11 @@ def start_debug(file_path: str, use_pytest: bool = False, args: str = "",
         file_path: Path to the Python file or test module to debug.
         use_pytest: If True, run using pytest with --pdb.
         args: Additional arguments to pass to the Python script or pytest (space-separated).
-        caveman_mode: If True (default), return compact output — no auto source context
-                      after navigation, no dir() in examine_variable.  Set False to get
-                      the full verbose output including 11-line source window after each step.
+        caveman_mode: Opt-in compact output mode (default False).  When True:
+                      skips the 11-line source window after navigation commands,
+                      omits dir() in examine_variable unless include_attrs=True,
+                      and strips bare (Pdb) prompts from output.  Use to reduce
+                      token usage when the agent doesn't need the full context.
     """
     globals()['caveman_mode'] = caveman_mode  # set module-level flag from param
     global pdb_process, pdb_running, current_file, current_project_root, output_thread
@@ -768,7 +859,11 @@ def start_debug(file_path: str, use_pytest: bool = False, args: str = "",
 
     except FileNotFoundError as e:
          pdb_running = False
-         return f"Error starting debugging session: Command not found ({e.filename}). Check that the required executable is installed and in PATH (system or venv).\n{traceback.format_exc()}"
+         return (
+             f"Error starting debugging session: Command not found "
+             f"({e.filename}). Check that the required executable is "
+             f"installed and in PATH (system or venv).\n{traceback.format_exc()}"
+         )
     except Exception as e:
         pdb_running = False
         return f"Error starting debugging session: {str(e)}\n{traceback.format_exc()}"
@@ -792,7 +887,10 @@ def send_pdb_command(command: str) -> str:
     global pdb_running, pdb_process, remote_socket, remote_mode
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug or connect_remote_debug first."
+        return (
+            "No active debugging session. "
+            "Use start_debug or connect_remote_debug first."
+        )
 
     # Double check connection liveness
     if remote_mode:
@@ -859,7 +957,10 @@ def set_breakpoint(file_path: str, line_number: int) -> str:
     global breakpoints, current_project_root
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug or connect_remote_debug first."
+        return (
+            "No active debugging session. "
+            "Use start_debug or connect_remote_debug first."
+        )
     if not current_project_root:
          return "Error: Project root not identified. Cannot reliably set breakpoint."
 
@@ -925,7 +1026,10 @@ def clear_breakpoint(file_path: str, line_number: int) -> str:
     global breakpoints, current_project_root
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug or connect_remote_debug first."
+        return (
+            "No active debugging session. "
+            "Use start_debug or connect_remote_debug first."
+        )
     if not current_project_root:
          return "Error: Project root not identified. Cannot reliably clear breakpoint."
 
@@ -986,7 +1090,10 @@ def list_breakpoints() -> str:
     global breakpoints, current_project_root
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug or connect_remote_debug first."
+        return (
+            "No active debugging session. "
+            "Use start_debug or connect_remote_debug first."
+        )
     if not current_project_root:
         # List only tracked BPs if PDB isn't running or root unknown
         tracked_bps_formatted = []
@@ -1100,7 +1207,10 @@ def examine_variable(variable_name: str, include_attrs: bool = False) -> str:
                        Always True when caveman_mode=False.
     """
     if not pdb_running:
-        return "No active debugging session. Use start_debug or connect_remote_debug first."
+        return (
+            "No active debugging session. "
+            "Use start_debug or connect_remote_debug first."
+        )
 
     if not caveman_mode:
         # Verbose path: exact original behaviour
@@ -1236,7 +1346,6 @@ def end_debug() -> str:
     Works for both local subprocess sessions and remote TCP sessions.
     """
     global pdb_process, pdb_running, output_thread
-    global remote_socket, remote_socket_file, remote_mode, remote_host, remote_port
 
     nothing_to_end = (
         not pdb_running
@@ -1260,16 +1369,18 @@ def end_debug() -> str:
                     time.sleep(0.2)
                 except Exception:
                     pass
+                # shutdown() before close() so a reader thread blocked in
+                # recv()/select() unblocks immediately on every POSIX impl.
+                try:
+                    remote_socket.shutdown(socket_module.SHUT_RDWR)
+                except OSError:
+                    pass
                 remote_socket.close()
                 print("Remote socket closed.")
             except Exception as e:
                 print(f"Error closing remote socket: {e}", file=sys.stderr)
                 result_message = f"Remote session ended with socket error: {e}"
-        remote_socket = None
-        remote_socket_file = None
-        remote_mode = False
-        remote_host = ""
-        remote_port = 0
+        _clear_remote_state()
 
     elif pdb_process and pdb_process.poll() is None:
         # --- Local process teardown ---
@@ -1316,9 +1427,12 @@ def end_debug() -> str:
             print(f"Error during end_debug: {e}", file=sys.stderr)
             result_message = f"Debugging session ended with errors: {e}"
 
-    # Clean up shared state
+    # Clean up shared state.  Also reset caveman_mode so a subsequent
+    # start_debug / connect_remote_debug call without the parameter does
+    # not silently inherit the previous session's output mode.
     pdb_process = None
     pdb_running = False
+    globals()['caveman_mode'] = False
 
     # Wait briefly for the output thread to potentially finish reading remaining output
     if output_thread and output_thread.is_alive():

--- a/src/mcp_pdb/main.py
+++ b/src/mcp_pdb/main.py
@@ -5,6 +5,8 @@ import re
 import shlex
 import shutil
 import signal
+import select
+import socket as socket_module
 import subprocess
 import sys
 import threading
@@ -27,6 +29,13 @@ current_use_pytest = False    # Flag indicating if pytest was used
 breakpoints = {}              # Tracks breakpoints: {abs_file_path: {line_num: {command_str, bp_number}}}
 output_thread = None          # Thread object for reading output
 
+# Remote PDB session state
+remote_socket = None          # Connected socket for remote PDB
+remote_socket_file = None     # Binary file wrapper used by the reader thread
+remote_mode = False           # True when connected to a remote PDB session
+remote_host = ""              # Remote hostname/IP
+remote_port = 0               # Remote TCP port
+
 # --- Helper Functions ---
 
 def read_pdb_output(process, output_queue):
@@ -41,7 +50,6 @@ def read_pdb_output(process, output_queue):
         print("PDB output reader: ValueError (stdout likely closed).", file=sys.stderr)
     except Exception as e:
         print(f"PDB output reader: Unexpected error: {e}", file=sys.stderr)
-        # Optionally log traceback here if needed
     finally:
         # Ensure stdout is closed if loop finishes normally or breaks
         if process and process.stdout and not process.stdout.closed:
@@ -50,6 +58,50 @@ def read_pdb_output(process, output_queue):
              except Exception as e:
                  print(f"PDB output reader: Error closing stdout: {e}", file=sys.stderr)
         print("PDB output reader thread finished.", file=sys.stderr)
+
+
+def read_socket_output(sock: socket_module.socket, output_queue: queue.Queue) -> None:
+    """Read output from a remote PDB socket and put it in the queue.
+
+    Uses recv() + select() instead of readline() so that the (Pdb) prompt
+    — which has no trailing newline — is emitted without blocking.
+
+    After draining all newline-terminated lines from a recv() chunk, a
+    select() with a short timeout checks whether more data is arriving
+    immediately.  If not, whatever remains in the buffer (typically
+    the bare '(Pdb) ' prompt) is emitted as-is.
+    """
+    buf = b""
+    try:
+        while True:
+            try:
+                chunk = sock.recv(4096)
+            except OSError as e:
+                print(f"Remote PDB reader: recv error: {e}", file=sys.stderr)
+                break
+            if not chunk:
+                break
+            buf += chunk
+
+            # Emit all newline-terminated lines
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                output_queue.put(line.decode("utf-8", errors="replace").rstrip())
+
+            # If residual bytes remain (no \n), check whether more data is
+            # arriving within 50 ms.  If not, emit them now — they are almost
+            # certainly the '(Pdb) ' prompt.
+            if buf:
+                r, _, _ = select.select([sock], [], [], 0.05)
+                if not r:
+                    output_queue.put(buf.decode("utf-8", errors="replace").rstrip())
+                    buf = b""
+    except Exception as e:
+        print(f"Remote PDB reader: unexpected error: {e}", file=sys.stderr)
+    finally:
+        if buf:
+            output_queue.put(buf.decode("utf-8", errors="replace").rstrip())
+        print("Remote PDB output reader thread finished.", file=sys.stderr)
 
 
 def get_pdb_output(timeout=0.5):
@@ -74,64 +126,109 @@ def get_pdb_output(timeout=0.5):
     return '\n'.join(output)
 
 
+def _is_local_process_alive():
+    """Return True if the local PDB subprocess is still running."""
+    return pdb_process is not None and pdb_process.poll() is None
+
+
+def _is_remote_connected():
+    """Return True if the remote socket is still open."""
+    return remote_socket is not None
+
+
 def send_to_pdb(command, timeout_multiplier=1.0):
-    """Send a command to the pdb process and get its response.
+    """Send a command to the pdb process (local or remote) and get its response.
+
+    Works for both:
+    - Local sessions (subprocess stdin/stdout)
+    - Remote sessions (TCP socket)
 
     Args:
         command: The PDB command to send
         timeout_multiplier: Multiplier to adjust timeout for complex commands
     """
-    global pdb_process, pdb_running
+    global pdb_process, pdb_running, remote_socket, remote_mode
 
-    if pdb_process and pdb_process.poll() is None:
-        # Clear queue before sending command to get only relevant output
-        while not pdb_output_queue.empty():
-            try: pdb_output_queue.get_nowait()
-            except queue.Empty: break
+    # Resolve and type-narrow the active transport before any I/O.
+    # Using local variables lets Pyright track non-None invariants.
+    if remote_mode:
+        if remote_socket is None:
+            if pdb_running:
+                pdb_running = False
+                final_output = get_pdb_output(timeout=0.1)
+                return f"No active remote pdb connection.\nFinal Output:\n{final_output}"
+            return "No active remote pdb connection."
+        pass  # remote_socket is non-None; accessed via assert below
+    else:
+        if pdb_process is None or pdb_process.poll() is not None:
+            if pdb_running:
+                pdb_running = False
+                final_output = get_pdb_output(timeout=0.1)
+                return f"No active pdb process (it terminated).\nFinal Output:\n{final_output}"
+            return "No active pdb process."
+        # pdb_process is non-None; accessed via assert below
 
-        try:
-            # Determine appropriate timeout based on command type
-            base_timeout = 1.5
-            if command.strip().lower() in ('c', 'continue', 'r', 'run', 'until', 'unt'):
-                timeout = base_timeout * 3 * timeout_multiplier
-            else:
-                timeout = base_timeout * timeout_multiplier
+    # Clear queue before sending command to get only relevant output
+    while not pdb_output_queue.empty():
+        try: pdb_output_queue.get_nowait()
+        except queue.Empty: break
 
-            pdb_process.stdin.write((command + '\n').encode('utf-8'))
-            pdb_process.stdin.flush()
-            # Wait a bit for command processing. Adjust if needed.
-            output = get_pdb_output(timeout=timeout) # Adjusted timeout for commands
+    try:
+        # Determine appropriate timeout based on command type
+        base_timeout = 1.5
+        if command.strip().lower() in ('c', 'continue', 'r', 'run', 'until', 'unt'):
+            timeout = base_timeout * 3 * timeout_multiplier
+        else:
+            timeout = base_timeout * timeout_multiplier
 
-            # Check if process ended right after the command
-            if pdb_process.poll() is not None:
-                 pdb_running = False
-                 # Try to get any final output
-                 final_output = get_pdb_output(timeout=0.1)
-                 return f"Command output:\n{output}\n{final_output}\n\n*** The debugging session has ended. ***"
+        if remote_mode:
+            # TCP socket: sendall is synchronous, no flush needed.
+            # remote_socket is non-None: checked and returned early above.
+            assert remote_socket is not None
+            remote_socket.sendall((command + '\n').encode('utf-8'))
+        else:
+            # pdb_process is non-None: checked and returned early above.
+            assert pdb_process is not None
+            stdin = pdb_process.stdin
+            if stdin is None:
+                return "Error: PDB process stdin is not available."
+            stdin.write((command + '\n').encode('utf-8'))
+            stdin.flush()
 
-            return output
+        output = get_pdb_output(timeout=timeout)
 
-        except (OSError, BrokenPipeError) as e:
-             print(f"Error writing to PDB stdin: {e}", file=sys.stderr)
-             pdb_running = False
-             # Try to get final output
-             final_output = get_pdb_output(timeout=0.1)
-             if pdb_process:
-                 pdb_process.terminate() # Ensure process is stopped
-                 pdb_process.wait(timeout=0.5)
-             return f"Error communicating with PDB: {e}\nFinal Output:\n{final_output}\n\n*** The debugging session has likely ended. ***"
-        except Exception as e:
-            print(f"Unexpected error in send_to_pdb: {e}", file=sys.stderr)
+        # For local sessions, check if process ended after the command
+        if not remote_mode and pdb_process is not None and pdb_process.poll() is not None:
             pdb_running = False
-            return f"Unexpected error sending command: {e}"
+            final_output = get_pdb_output(timeout=0.1)
+            return (f"Command output:\n{output}\n{final_output}\n\n"
+                    "*** The debugging session has ended. ***")
 
-    elif pdb_running:
-        # Process exists but poll() is not None, means it terminated
+        return output
+
+    except (OSError, BrokenPipeError) as e:
+        print(f"Error writing to PDB: {e}", file=sys.stderr)
         pdb_running = False
         final_output = get_pdb_output(timeout=0.1)
-        return f"No active pdb process (it terminated).\nFinal Output:\n{final_output}"
-    else:
-        return "No active pdb process."
+        if not remote_mode:
+            if pdb_process:
+                pdb_process.terminate()
+                pdb_process.wait(timeout=0.5)
+        else:
+            rsock = remote_socket
+            if rsock is not None:
+                try:
+                    rsock.close()
+                except Exception:
+                    pass
+            remote_socket = None
+        return (f"Error communicating with PDB: {e}\n"
+                f"Final Output:\n{final_output}\n\n"
+                "*** The debugging session has likely ended. ***")
+    except Exception as e:
+        print(f"Unexpected error in send_to_pdb: {e}", file=sys.stderr)
+        pdb_running = False
+        return f"Unexpected error sending command: {e}"
 
 
 def find_project_root(start_path):
@@ -253,6 +350,123 @@ def sanitize_arguments(args_str):
 
 
 # --- MCP Tools ---
+
+@mcp.tool()
+def connect_remote_debug(host: str = "localhost", port: int = 4444,
+                          timeout: int = 30) -> str:
+    """Connect to a remote PDB session listening on a TCP socket.
+
+    The remote Python process must expose PDB over a network socket, for example
+    using the `remote-pdb` package:
+
+        from remote_pdb import RemotePdb
+        RemotePdb('0.0.0.0', 4444).set_trace()
+
+    Or with a custom setup:
+
+        import pdb, socket, io
+        s = socket.socket(); s.bind(('0.0.0.0', 4444)); s.listen(1)
+        conn, _ = s.accept()
+        f = conn.makefile('rwb', buffering=0)
+        pdb.Pdb(stdin=io.TextIOWrapper(f), stdout=io.TextIOWrapper(f)).set_trace()
+
+    Once connected all existing tools (send_pdb_command, set_breakpoint, etc.)
+    work exactly the same as for a local session.
+
+    Args:
+        host:    Hostname or IP address of the remote machine (default "localhost").
+        port:    TCP port the remote PDB is listening on (default 4444).
+        timeout: Seconds to wait for a successful connection, retrying on
+                 ConnectionRefused (default 30).  Set to 0 for a single attempt.
+    """
+    global pdb_running, remote_socket, remote_socket_file, remote_mode
+    global remote_host, remote_port, output_thread, pdb_output_queue
+
+    if pdb_running:
+        if remote_mode:
+            return (f"Already connected to remote PDB at {remote_host}:{remote_port}. "
+                    "Use end_debug first.")
+        else:
+            return (f"Local debugging session already running for {current_file}. "
+                    "Use end_debug first.")
+
+    # Clear the output queue
+    while not pdb_output_queue.empty():
+        try: pdb_output_queue.get_nowait()
+        except queue.Empty: break
+
+    # Attempt connection, retrying until timeout
+    deadline = time.monotonic() + max(timeout, 0)
+    last_error = None
+    sock = None
+    first_attempt = True
+
+    print(f"Connecting to remote PDB at {host}:{port} (timeout={timeout}s)...")
+    while True:
+        try:
+            sock = socket_module.socket(socket_module.AF_INET, socket_module.SOCK_STREAM)
+            sock.settimeout(5.0)
+            sock.connect((host, port))
+            sock.settimeout(None)  # Switch to blocking after connect
+            print(f"Connected to {host}:{port}")
+            break
+        except (ConnectionRefusedError, OSError) as e:
+            last_error = e
+            if sock:
+                try: sock.close()
+                except Exception: pass
+                sock = None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or (first_attempt and timeout == 0):
+                break
+            print(f"Connection refused ({e}), retrying... ({remaining:.1f}s remaining)")
+            time.sleep(min(1.0, remaining))
+        first_attempt = False
+
+    if sock is None:
+        return (f"Failed to connect to {host}:{port} within {timeout}s. "
+                f"Last error: {last_error}")
+
+    try:
+        # Ensure previous output thread is not hanging around
+        if output_thread and output_thread.is_alive():
+            print("Warning: Previous output thread was still alive.", file=sys.stderr)
+
+        # Pass the raw socket — read_socket_output uses recv()+select()
+        # so it can emit the (Pdb) prompt that has no trailing newline.
+        t = threading.Thread(
+            target=read_socket_output,
+            args=(sock, pdb_output_queue),
+            daemon=True,
+        )
+        t.start()
+        output_thread = t
+
+        # Wait for the initial (Pdb) prompt from the remote side
+        print("Waiting for remote PDB prompt...")
+        initial_output = get_pdb_output(timeout=5.0)
+
+        if not initial_output.strip():
+            initial_output = ("(No initial output received yet. "
+                              "The remote process may be waiting for execution to reach "
+                              "the set_trace() call, or it is already at a prompt.)")
+
+        # Commit remote state
+        remote_socket = sock
+        remote_socket_file = None  # raw socket used directly; no file wrapper
+        remote_mode = True
+        remote_host = host
+        remote_port = port
+        pdb_running = True
+
+        return (f"Connected to remote PDB at {host}:{port}\n\n"
+                f"Initial output:\n{initial_output}")
+
+    except Exception as e:
+        try: sock.close()
+        except Exception: pass
+        return f"Error setting up remote connection: {e}\n{traceback.format_exc()}"
+
 
 @mcp.tool()
 def start_debug(file_path: str, use_pytest: bool = False, args: str = "") -> str:
@@ -379,6 +593,9 @@ def start_debug(file_path: str, use_pytest: bool = False, args: str = "") -> str
             cmd = base_cmd + [rel_file_path] + parsed_args
         elif venv_python_path:
             print(f"Using venv Python: {venv_python_path}")
+            # find_venv_details returns (python_path, bin_dir) as a pair;
+            # venv_bin_dir is non-None whenever venv_python_path is non-None.
+            assert venv_bin_dir is not None
             venv_dir = os.path.dirname(os.path.dirname(venv_bin_dir)) # Get actual venv root
             env['VIRTUAL_ENV'] = venv_dir
             env['PATH'] = f"{venv_bin_dir}{os.pathsep}{env.get('PATH', '')}"
@@ -532,7 +749,7 @@ def start_debug(file_path: str, use_pytest: bool = False, args: str = "") -> str
 
     except FileNotFoundError as e:
          pdb_running = False
-         return f"Error starting debugging session: Command not found ({e.filename}). Is '{cmd[0]}' installed and in the correct PATH (system or venv)?\n{traceback.format_exc()}"
+         return f"Error starting debugging session: Command not found ({e.filename}). Check that the required executable is installed and in PATH (system or venv).\n{traceback.format_exc()}"
     except Exception as e:
         pdb_running = False
         return f"Error starting debugging session: {str(e)}\n{traceback.format_exc()}"
@@ -553,16 +770,21 @@ def send_pdb_command(command: str) -> str:
     Args:
         command: The PDB command string.
     """
-    global pdb_running, pdb_process
+    global pdb_running, pdb_process, remote_socket, remote_mode
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug first."
+        return "No active debugging session. Use start_debug or connect_remote_debug first."
 
-    # Double check process liveness
-    if pdb_process is None or pdb_process.poll() is not None:
-         pdb_running = False
-         final_output = get_pdb_output(timeout=0.1)
-         return f"The debugging session appears to have ended.\nFinal Output:\n{final_output}"
+    # Double check connection liveness
+    if remote_mode:
+        if not _is_remote_connected():
+            pdb_running = False
+            return "Remote debugging connection closed."
+    else:
+        if pdb_process is None or pdb_process.poll() is not None:
+            pdb_running = False
+            final_output = get_pdb_output(timeout=0.1)
+            return f"The debugging session appears to have ended.\nFinal Output:\n{final_output}"
 
     try:
         # Determine appropriate timeout based on command complexity
@@ -580,28 +802,30 @@ def send_pdb_command(command: str) -> str:
         # Provide extra context for common navigation commands
         # Only do this if the session is still running
         nav_commands = ['n', 's', 'c', 'r', 'unt', 'until', 'next', 'step', 'continue', 'return']
-        if command.strip().lower() in nav_commands and pdb_running and pdb_process.poll() is None:
-            # Give PDB a tiny bit more time after navigation before asking for location
-            # Check again if it's running before sending 'l .'
-            if pdb_running and pdb_process.poll() is None:
+        if command.strip().lower() in nav_commands and pdb_running:
+            still_active = _is_remote_connected() if remote_mode else _is_local_process_alive()
+            if still_active:
                 print("Fetching context after navigation...")
                 line_context = send_to_pdb("l .")
-                 # Check again after sending 'l .'
-                if pdb_running and pdb_process.poll() is None:
+                still_active2 = _is_remote_connected() if remote_mode else _is_local_process_alive()
+                if pdb_running and still_active2:
                     response += f"\n\n-- Current location --\n{line_context}"
                 else:
                     response += "\n\n-- Session ended after navigation --"
-                    pdb_running = False # Ensure state is correct
+                    pdb_running = False
 
         return f"Command output:\n{response}"
 
     except Exception as e:
         # Catch unexpected errors during command sending/processing
         print(f"Error in send_pdb_command: {e}", file=sys.stderr)
-        # Check process status again
-        if pdb_process and pdb_process.poll() is not None:
+        # Check connection status again
+        still_active = _is_remote_connected() if remote_mode else _is_local_process_alive()
+        if not still_active:
              pdb_running = False
-             return f"Error sending command: {str(e)}\n\n*** The debugging session has likely ended. ***\n{traceback.format_exc()}"
+             return (f"Error sending command: {str(e)}\n\n"
+                     "*** The debugging session has likely ended. ***\n"
+                     f"{traceback.format_exc()}")
         else:
              return f"Error sending command: {str(e)}\n{traceback.format_exc()}"
 
@@ -617,7 +841,7 @@ def set_breakpoint(file_path: str, line_number: int) -> str:
     global breakpoints, current_project_root
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug first."
+        return "No active debugging session. Use start_debug or connect_remote_debug first."
     if not current_project_root:
          return "Error: Project root not identified. Cannot reliably set breakpoint."
 
@@ -683,7 +907,7 @@ def clear_breakpoint(file_path: str, line_number: int) -> str:
     global breakpoints, current_project_root
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug first."
+        return "No active debugging session. Use start_debug or connect_remote_debug first."
     if not current_project_root:
          return "Error: Project root not identified. Cannot reliably clear breakpoint."
 
@@ -744,7 +968,7 @@ def list_breakpoints() -> str:
     global breakpoints, current_project_root
 
     if not pdb_running:
-        return "No active debugging session. Use start_debug first."
+        return "No active debugging session. Use start_debug or connect_remote_debug first."
     if not current_project_root:
         # List only tracked BPs if PDB isn't running or root unknown
         tracked_bps_formatted = []
@@ -790,9 +1014,29 @@ def list_breakpoints() -> str:
 
 @mcp.tool()
 def restart_debug() -> str:
-    """Restart the debugging session with the same file, arguments, and pytest flag."""
-    global pdb_process, pdb_running, current_file, current_args, current_use_pytest
+    """Restart the debugging session with the same file/connection, arguments, and pytest flag.
 
+    For remote sessions: reconnects to the same host and port.
+    For local sessions: relaunches the same file with the same arguments.
+    """
+    global pdb_process, pdb_running, current_file, current_args, current_use_pytest
+    global remote_mode, remote_host, remote_port
+
+    if remote_mode:
+        # Remote restart: close current connection and reconnect
+        stored_host = remote_host
+        stored_port = remote_port
+        if not stored_host:
+            return "No remote session was previously started to restart."
+
+        print(f"Attempting to reconnect to remote PDB at {stored_host}:{stored_port}...")
+        end_result = end_debug()
+        reconnect_result = connect_remote_debug(host=stored_host, port=stored_port)
+        return (f"--- Remote Restart Attempt ---\n"
+                f"Previous session end result: {end_result}\n\n"
+                f"Reconnection status:\n{reconnect_result}")
+
+    # Local restart
     if not current_file:
         return "No debugging session was previously started (or state lost) to restart."
 
@@ -836,7 +1080,7 @@ def examine_variable(variable_name: str) -> str:
         variable_name: Name of the variable to examine (e.g., 'my_var', 'self.data').
     """
     if not pdb_running:
-        return "No active debugging session. Use start_debug first."
+        return "No active debugging session. Use start_debug or connect_remote_debug first."
 
     # Basic print
     p_command = f"p {variable_name}"
@@ -878,17 +1122,24 @@ def examine_variable(variable_name: str) -> str:
 def get_debug_status() -> str:
     """Get the current status of the debugging session and tracked state."""
     global pdb_running, current_file, current_project_root, breakpoints, pdb_process
+    global remote_mode, remote_host, remote_port, remote_socket
 
     if not pdb_running:
-         # Check if process exists but isn't running
+         if remote_mode and remote_socket is None:
+             return "Remote debugging connection closed."
          if pdb_process and pdb_process.poll() is not None:
-              return "Debugging session ended. Process terminated."
+             return "Debugging session ended. Process terminated."
          return "No active debugging session."
 
-    # Check process liveness again
-    if pdb_process and pdb_process.poll() is not None:
-        pdb_running = False
-        return "Debugging session has ended (process terminated)."
+    # Check connection liveness
+    if remote_mode:
+        if not _is_remote_connected():
+            pdb_running = False
+            return "Remote debugging connection has been closed."
+    else:
+        if pdb_process and pdb_process.poll() is not None:
+            pdb_running = False
+            return "Debugging session has ended (process terminated)."
 
     # Format tracked breakpoints for status
     bp_list = []
@@ -905,49 +1156,87 @@ def get_debug_status() -> str:
             else:
                 bp_list.append(f"{rel_path}:{line_num}")
 
-    status = {
-        "running": pdb_running,
-        "current_file": current_file,
-        "project_root": current_project_root,
-        "use_pytest": current_use_pytest,
-        "arguments": current_args,
-        "process_id": pdb_process.pid if pdb_process else None,
-        "tracked_breakpoints": bp_list,
-    }
+    if remote_mode:
+        status_lines = [
+            "--- Debug Session Status ---",
+            f"Running: {pdb_running}",
+            f"Mode: remote",
+            f"Remote host: {remote_host}:{remote_port}",
+            f"Project Root: {current_project_root or '(not set)'}",
+            f"Tracked Breakpoints: {bp_list or 'None'}",
+        ]
+    else:
+        status_lines = [
+            "--- Debug Session Status ---",
+            f"Running: {pdb_running}",
+            f"Mode: local",
+            f"PID: {pdb_process.pid if pdb_process else None}",
+            f"Project Root: {current_project_root}",
+            f"Debugging File: {current_file}",
+            f"Using Pytest: {current_use_pytest}",
+            f"Arguments: '{current_args}'",
+            f"Tracked Breakpoints: {bp_list or 'None'}",
+        ]
 
     # Try to get current location from PDB without advancing
     current_loc_output = "[Could not query PDB location]"
-    if pdb_running and pdb_process and pdb_process.poll() is None:
-         current_loc_output = send_to_pdb("l .") # Get location without changing state
-         if not pdb_running: # Check if the query itself ended the session
-             status["running"] = False
-             current_loc_output += "\n -- Session ended during status check --"
+    still_active = _is_remote_connected() if remote_mode else _is_local_process_alive()
+    if pdb_running and still_active:
+        current_loc_output = send_to_pdb("l .")
+        if not pdb_running:
+            current_loc_output += "\n -- Session ended during status check --"
 
-
-    return "--- Debug Session Status ---\n" + \
-           f"Running: {status['running']}\n" + \
-           f"PID: {status['process_id']}\n" + \
-           f"Project Root: {status['project_root']}\n" + \
-           f"Debugging File: {status['current_file']}\n" + \
-           f"Using Pytest: {status['use_pytest']}\n" + \
-           f"Arguments: '{status['arguments']}'\n" + \
-           f"Tracked Breakpoints: {status['tracked_breakpoints'] or 'None'}\n\n" + \
-           f"-- Current PDB Location --\n{current_loc_output}\n" + \
-           "--- End Status ---"
+    status_lines.append("")
+    status_lines.append("-- Current PDB Location --")
+    status_lines.append(current_loc_output)
+    status_lines.append("--- End Status ---")
+    return '\n'.join(status_lines)
 
 
 @mcp.tool()
 def end_debug() -> str:
-    """End the current debugging session forcefully."""
-    global pdb_process, pdb_running, output_thread
+    """End the current debugging session forcefully.
 
-    if not pdb_running and (pdb_process is None or pdb_process.poll() is not None):
+    Works for both local subprocess sessions and remote TCP sessions.
+    """
+    global pdb_process, pdb_running, output_thread
+    global remote_socket, remote_socket_file, remote_mode, remote_host, remote_port
+
+    nothing_to_end = (
+        not pdb_running
+        and (pdb_process is None or pdb_process.poll() is not None)
+        and remote_socket is None
+    )
+    if nothing_to_end:
         return "No active debugging session to end."
 
     print("Ending debugging session...")
     result_message = "Debugging session ended."
 
-    if pdb_process and pdb_process.poll() is None:
+    if remote_mode:
+        # --- Remote session teardown ---
+        print(f"Closing remote PDB connection to {remote_host}:{remote_port}...")
+        if remote_socket:
+            try:
+                # Politely ask PDB to quit before closing
+                try:
+                    remote_socket.sendall(b'q\n')
+                    time.sleep(0.2)
+                except Exception:
+                    pass
+                remote_socket.close()
+                print("Remote socket closed.")
+            except Exception as e:
+                print(f"Error closing remote socket: {e}", file=sys.stderr)
+                result_message = f"Remote session ended with socket error: {e}"
+        remote_socket = None
+        remote_socket_file = None
+        remote_mode = False
+        remote_host = ""
+        remote_port = 0
+
+    elif pdb_process and pdb_process.poll() is None:
+        # --- Local process teardown ---
         try:
             # Try sending SIGINT (Ctrl+C) first for cleaner exit
             if sys.platform != "win32":
@@ -964,8 +1253,9 @@ def end_debug() -> str:
             if pdb_process.poll() is None:
                 try:
                     print("Attempting graceful exit with 'q'...")
-                    pdb_process.stdin.write(b'q\n')
-                    pdb_process.stdin.flush()
+                    if pdb_process.stdin is not None:
+                        pdb_process.stdin.write(b'q\n')
+                        pdb_process.stdin.flush()
                     # Wait briefly for potential cleanup
                     pdb_process.wait(timeout=0.5)
                     print("PDB process quit gracefully.")
@@ -990,7 +1280,7 @@ def end_debug() -> str:
             print(f"Error during end_debug: {e}", file=sys.stderr)
             result_message = f"Debugging session ended with errors: {e}"
 
-    # Clean up state
+    # Clean up shared state
     pdb_process = None
     pdb_running = False
 
@@ -1014,9 +1304,9 @@ def end_debug() -> str:
 # --- Cleanup on Exit ---
 
 def cleanup():
-    """Ensure the PDB process is terminated when the MCP server exits."""
+    """Ensure the PDB process / remote socket is closed when the MCP server exits."""
     print("Running atexit cleanup...")
-    if pdb_running or (pdb_process and pdb_process.poll() is None):
+    if pdb_running or (pdb_process and pdb_process.poll() is None) or remote_socket is not None:
         end_debug()
 
 atexit.register(cleanup)

--- a/src/mcp_pdb/main.py
+++ b/src/mcp_pdb/main.py
@@ -28,6 +28,7 @@ current_args = ""             # Additional args passed to the script/pytest
 current_use_pytest = False    # Flag indicating if pytest was used
 breakpoints = {}              # Tracks breakpoints: {abs_file_path: {line_num: {command_str, bp_number}}}
 output_thread = None          # Thread object for reading output
+caveman_mode = False          # When True: compact output; False (default): full verbose output
 
 # Remote PDB session state
 remote_socket = None          # Connected socket for remote PDB
@@ -123,7 +124,19 @@ def get_pdb_output(timeout=0.5):
                 break
         except queue.Empty:
             break # Timeout reached
-    return '\n'.join(output)
+    # In caveman_mode: strip bare '(Pdb)' prompt lines and the '(Pdb) ' prefix
+    # that appears on the first response line when the reader was blocked on the
+    # previous prompt.  In verbose mode keep the raw output unchanged.
+    if not caveman_mode:
+        return '\n'.join(output)
+    cleaned = []
+    for line in output:
+        if line.strip() == '(Pdb)':
+            continue
+        if line.startswith('(Pdb) '):
+            line = line[6:]
+        cleaned.append(line)
+    return '\n'.join(cleaned)
 
 
 def _is_local_process_alive():
@@ -353,7 +366,7 @@ def sanitize_arguments(args_str):
 
 @mcp.tool()
 def connect_remote_debug(host: str = "localhost", port: int = 4444,
-                          timeout: int = 30) -> str:
+                          timeout: int = 30, caveman_mode: bool = False) -> str:
     """Connect to a remote PDB session listening on a TCP socket.
 
     The remote Python process must expose PDB over a network socket, for example
@@ -379,6 +392,7 @@ def connect_remote_debug(host: str = "localhost", port: int = 4444,
         timeout: Seconds to wait for a successful connection, retrying on
                  ConnectionRefused (default 30).  Set to 0 for a single attempt.
     """
+    globals()['caveman_mode'] = caveman_mode  # set module-level flag from param
     global pdb_running, remote_socket, remote_socket_file, remote_mode
     global remote_host, remote_port, output_thread, pdb_output_queue
 
@@ -469,14 +483,19 @@ def connect_remote_debug(host: str = "localhost", port: int = 4444,
 
 
 @mcp.tool()
-def start_debug(file_path: str, use_pytest: bool = False, args: str = "") -> str:
+def start_debug(file_path: str, use_pytest: bool = False, args: str = "",
+                caveman_mode: bool = False) -> str:
     """Start a debugging session on a Python file within its project context.
 
     Args:
         file_path: Path to the Python file or test module to debug.
         use_pytest: If True, run using pytest with --pdb.
         args: Additional arguments to pass to the Python script or pytest (space-separated).
+        caveman_mode: If True (default), return compact output — no auto source context
+                      after navigation, no dir() in examine_variable.  Set False to get
+                      the full verbose output including 11-line source window after each step.
     """
+    globals()['caveman_mode'] = caveman_mode  # set module-level flag from param
     global pdb_process, pdb_running, current_file, current_project_root, output_thread
     global pdb_output_queue, breakpoints, current_args, current_use_pytest
 
@@ -799,20 +818,19 @@ def send_pdb_command(command: str) -> str:
         if not pdb_running: # send_to_pdb might set this if process ended
              return f"Command output:\n{response}" # Response already includes end notice
 
-        # Provide extra context for common navigation commands
-        # Only do this if the session is still running
-        nav_commands = ['n', 's', 'c', 'r', 'unt', 'until', 'next', 'step', 'continue', 'return']
-        if command.strip().lower() in nav_commands and pdb_running:
-            still_active = _is_remote_connected() if remote_mode else _is_local_process_alive()
-            if still_active:
-                print("Fetching context after navigation...")
-                line_context = send_to_pdb("l .")
-                still_active2 = _is_remote_connected() if remote_mode else _is_local_process_alive()
-                if pdb_running and still_active2:
-                    response += f"\n\n-- Current location --\n{line_context}"
-                else:
-                    response += "\n\n-- Session ended after navigation --"
-                    pdb_running = False
+        # In verbose mode, fetch 11-line source context after navigation commands
+        if not caveman_mode:
+            nav_commands = ['n', 's', 'c', 'r', 'unt', 'until', 'next', 'step', 'continue', 'return']
+            if command.strip().lower() in nav_commands and pdb_running:
+                still_active = _is_remote_connected() if remote_mode else _is_local_process_alive()
+                if still_active:
+                    line_context = send_to_pdb("l .")
+                    still_active2 = _is_remote_connected() if remote_mode else _is_local_process_alive()
+                    if pdb_running and still_active2:
+                        response += f"\n\n-- Current location --\n{line_context}"
+                    else:
+                        response += "\n\n-- Session ended after navigation --"
+                        pdb_running = False
 
         return f"Command output:\n{response}"
 
@@ -1073,49 +1091,65 @@ def restart_debug() -> str:
 
 
 @mcp.tool()
-def examine_variable(variable_name: str) -> str:
-    """Examine a variable's type, value (print), and attributes (dir) using PDB.
+def examine_variable(variable_name: str, include_attrs: bool = False) -> str:
+    """Examine a variable's value and type using PDB.
 
     Args:
         variable_name: Name of the variable to examine (e.g., 'my_var', 'self.data').
+        include_attrs: If True, also show dir() attribute list. Default False.
+                       Always True when caveman_mode=False.
     """
     if not pdb_running:
         return "No active debugging session. Use start_debug or connect_remote_debug first."
 
-    # Basic print
-    p_command = f"p {variable_name}"
-    print(f"Sending command: {p_command}")
-    basic_info = send_to_pdb(p_command)
-    if not pdb_running: return f"Session ended after 'p {variable_name}'. Output:\n{basic_info}"
+    if not caveman_mode:
+        # Verbose path: exact original behaviour
+        p_command = f"p {variable_name}"
+        print(f"Sending command: {p_command}")
+        basic_info = send_to_pdb(p_command)
+        if not pdb_running: return f"Session ended after 'p {variable_name}'. Output:\n{basic_info}"
 
-    # Type info
-    type_command = f"p type({variable_name})"
-    print(f"Sending command: {type_command}")
-    type_info = send_to_pdb(type_command)
-    # Check if session ended, but proceed if possible
-    if not pdb_running and "Session ended" not in basic_info :
-        return f"Value:\n{basic_info}\n\nSession ended after 'p type({variable_name})'. Type Output:\n{type_info}"
+        type_command = f"p type({variable_name})"
+        print(f"Sending command: {type_command}")
+        type_info = send_to_pdb(type_command)
+        if not pdb_running and "Session ended" not in basic_info:
+            return f"Value:\n{basic_info}\n\nSession ended after 'p type({variable_name})'. Type Output:\n{type_info}"
 
-    # Attributes/methods using dir(), protect with try-except in PDB
-    dir_command = f"import inspect; print(dir({variable_name}))" # More robust than just dir()
-    print("Sending command: (inspect dir)")
-    dir_info = send_to_pdb(dir_command)
-    if not pdb_running and "Session ended" not in type_info :
-         return f"Value:\n{basic_info}\n\nType:\n{type_info}\n\nSession ended after 'dir()'. Dir Output:\n{dir_info}"
+        dir_command = f"import inspect; print(dir({variable_name}))"
+        print("Sending command: (inspect dir)")
+        dir_info = send_to_pdb(dir_command)
+        if not pdb_running and "Session ended" not in type_info:
+            return f"Value:\n{basic_info}\n\nType:\n{type_info}\n\nSession ended after 'dir()'. Dir Output:\n{dir_info}"
 
-    # Pretty print (useful for complex objects)
-    pp_command = f"pp {variable_name}"
-    print(f"Sending command: {pp_command}")
-    pretty_info = send_to_pdb(pp_command)
-    if not pdb_running and "Session ended" not in dir_info :
-         return f"Value:\n{basic_info}\n\nType:\n{type_info}\n\nAttributes/Methods:\n{dir_info}\n\nSession ended after 'pp'. PP Output:\n{pretty_info}"
+        pp_command = f"pp {variable_name}"
+        print(f"Sending command: {pp_command}")
+        pretty_info = send_to_pdb(pp_command)
+        if not pdb_running and "Session ended" not in dir_info:
+            return f"Value:\n{basic_info}\n\nType:\n{type_info}\n\nAttributes/Methods:\n{dir_info}\n\nSession ended after 'pp'. PP Output:\n{pretty_info}"
 
-    return (f"--- Variable Examination: {variable_name} ---\n\n"
-            f"Value (p):\n{basic_info}\n\n"
-            f"Pretty Value (pp):\n{pretty_info}\n\n"
-            f"Type (p type()):\n{type_info}\n\n"
-            f"Attributes/Methods (dir()):\n{dir_info}\n"
-            f"--- End Examination ---")
+        return (f"--- Variable Examination: {variable_name} ---\n\n"
+                f"Value (p):\n{basic_info}\n\n"
+                f"Pretty Value (pp):\n{pretty_info}\n\n"
+                f"Type (p type()):\n{type_info}\n\n"
+                f"Attributes/Methods (dir()):\n{dir_info}\n"
+                f"--- End Examination ---")
+
+    # Caveman path: compact value + type, optional attrs on request
+    basic_info = send_to_pdb(f"p {variable_name}")
+    if not pdb_running:
+        return f"Session ended. Output:\n{basic_info}"
+
+    type_info = send_to_pdb(f"p type({variable_name})")
+    if not pdb_running:
+        return f"Value: {basic_info}\nSession ended during type query."
+
+    result = f"Value: {basic_info}\nType:  {type_info}"
+
+    if include_attrs and pdb_running:
+        dir_info = send_to_pdb(f"import inspect; print(dir({variable_name}))")
+        result += f"\nAttrs: {dir_info}"
+
+    return result
 
 
 @mcp.tool()
@@ -1178,16 +1212,18 @@ def get_debug_status() -> str:
             f"Tracked Breakpoints: {bp_list or 'None'}",
         ]
 
-    # Try to get current location from PDB without advancing
+    # caveman_mode: compact 'w' (stack trace); verbose: full 'l .' source window
+    loc_cmd = "l ." if not caveman_mode else "w"
+    loc_label = "-- Current location --" if not caveman_mode else "-- Stack (w) --"
     current_loc_output = "[Could not query PDB location]"
     still_active = _is_remote_connected() if remote_mode else _is_local_process_alive()
     if pdb_running and still_active:
-        current_loc_output = send_to_pdb("l .")
+        current_loc_output = send_to_pdb(loc_cmd)
         if not pdb_running:
             current_loc_output += "\n -- Session ended during status check --"
 
     status_lines.append("")
-    status_lines.append("-- Current PDB Location --")
+    status_lines.append(loc_label)
     status_lines.append(current_loc_output)
     status_lines.append("--- End Status ---")
     return '\n'.join(status_lines)

--- a/src/mcp_pdb/main.py
+++ b/src/mcp_pdb/main.py
@@ -1305,8 +1305,8 @@ def end_debug() -> str:
 
 def cleanup():
     """Ensure the PDB process / remote socket is closed when the MCP server exits."""
-    print("Running atexit cleanup...")
     if pdb_running or (pdb_process and pdb_process.poll() is None) or remote_socket is not None:
+        print("Running atexit cleanup...")
         end_debug()
 
 atexit.register(cleanup)

--- a/src/mcp_pdb/rpdb.py
+++ b/src/mcp_pdb/rpdb.py
@@ -22,28 +22,40 @@ Usage modes:
        python -m pdb --pdbcls=mcp_pdb.rpdb:Debugger script.py
        pytest --pdb --pdbcls=mcp_pdb.rpdb:Debugger
 
-Env vars:  REMOTE_PDB_HOST (default 127.0.0.1)  REMOTE_PDB_PORT (default 4444)
+Env vars:
+  REMOTE_PDB_HOST              default 127.0.0.1
+  REMOTE_PDB_PORT              default 4444
+  REMOTE_PDB_ACCEPT_TIMEOUT    seconds DualPdb will wait for a client to
+                               connect before giving up (default 600).
+                               Set to 0 to wait forever.
 """
 import os
 import pdb as _pdb
+import select
 import socket as _socket
 import sys
+from types import FrameType
 from typing import IO, cast
 
 from remote_pdb import RemotePdb as _RemotePdb
 
 _HOST = os.environ.get("REMOTE_PDB_HOST", "127.0.0.1")
 _PORT = int(os.environ.get("REMOTE_PDB_PORT", "4444"))
+# Bounded accept() by default so non-interactive runs (CI, nohup) do not
+# hang indefinitely when no mcp client ever connects.  Ten minutes is
+# invisible to humans and an explicit upper bound for robots.  Set to 0
+# to preserve the pre-fix "wait forever" behaviour.
+_ACCEPT_TIMEOUT = float(os.environ.get("REMOTE_PDB_ACCEPT_TIMEOUT", "600"))
 
 
-# ── modes 2 / 3 ───────────────────────────────────────────────────────────────
+# --- modes 2 / 3 -----------------------------------------------------------
 
 def set_trace(host: str = _HOST, port: int = _PORT) -> None:
     """Drop-in for pdb.set_trace(). Blocks until a client connects."""
     _RemotePdb(host, port).set_trace(frame=sys._getframe().f_back)
 
 
-# ── mode 4  (Python >= 3.11 --pdbcls, remote-only) ───────────────────────────
+# --- mode 4  (Python >= 3.11 --pdbcls, remote-only) ------------------------
 
 class Debugger(_RemotePdb):
     """Absorbs pdb.Pdb __init__ kwargs; uses REMOTE_PDB_HOST/PORT."""
@@ -51,7 +63,7 @@ class Debugger(_RemotePdb):
         _RemotePdb.__init__(self, host=_HOST, port=_PORT)
 
 
-# ── mode 1  helpers ───────────────────────────────────────────────────────────
+# --- mode 1  helpers -------------------------------------------------------
 
 class _TeeOutput:
     """Write PDB output to both local stdout and remote socket simultaneously."""
@@ -67,8 +79,20 @@ class _TeeOutput:
         if self._conn_alive:
             try:
                 self._conn.sendall(data.encode("utf-8", errors="replace"))
-            except OSError:
-                self._conn_alive = False  # stop trying after first failure
+            except OSError as e:
+                # Log once to local stderr so the user knows the remote
+                # dropped and isn't still waiting for agent interaction.
+                # The agent itself discovers the dead connection on its
+                # next send_pdb_command (sendall raises) — we deliberately
+                # do not push a sentinel into the output queue because
+                # that would create a second error-signal channel that
+                # can diverge from the first.
+                print(
+                    f"rpdb: remote client disconnected ({e}); "
+                    "continuing in local-only mode.",
+                    file=sys.__stderr__, flush=True,
+                )
+                self._conn_alive = False
 
     def flush(self) -> None:
         self._local.flush()
@@ -96,21 +120,21 @@ class _SelectStdin:
         self._local = local
         self._remote = sock_file
         self._fds: list[IO[str]] = [local, sock_file]
+        # Cache references on self so they survive pdb._runscript() clearing
+        # __main__.__dict__ when this module happens to be __main__.
+        self._select = select
+        self._sys = sys
         # Drain any bytes buffered in stdin before the debugger starts
         # (e.g. Delete / arrow-key escape sequences left over from the shell).
-        import select as _sel, os as _os
         try:
-            if _sel.select([local], [], [], 0)[0]:
-                _os.read(local.fileno(), 4096)
+            if select.select([local], [], [], 0)[0]:
+                os.read(local.fileno(), 4096)
         except Exception:
             pass
 
     def readline(self) -> str:
-        # pdb._runscript() clears __main__.__dict__ before starting the
-        # debuggee.  Re-import here so names are always available regardless
-        # of whether this module is __main__ or an installed package.
-        import select as _sel
-        import sys as _sys
+        _sel = self._select
+        _sys = self._sys
 
         while self._fds:
             try:
@@ -158,7 +182,7 @@ class _SelectStdin:
         return getattr(self._local, "encoding", "utf-8")
 
 
-# ── mode 1  DualPdb ───────────────────────────────────────────────────────────
+# --- mode 1  DualPdb -------------------------------------------------------
 
 class DualPdb(_pdb.Pdb):
     """PDB that serves both the local terminal and a remote mcp-pdb client.
@@ -175,13 +199,35 @@ class DualPdb(_pdb.Pdb):
 
     def __init__(self, host: str = _HOST, port: int = _PORT, **_: object) -> None:
         srv = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
-        srv.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, True)
-        srv.bind((host, port))
-        print(f"rpdb: waiting for mcp connection on {host}:{port} ...",
-              file=sys.__stderr__, flush=True)
-        srv.listen(1)
-        self._conn, addr = srv.accept()
-        srv.close()
+        # No SO_REUSEADDR: a fresh bind on every invocation removes the
+        # local-user race for accept() on shared dev hosts.
+        try:
+            srv.bind((host, port))
+            # Bounded accept() unless the user explicitly asked for
+            # wait-forever via REMOTE_PDB_ACCEPT_TIMEOUT=0.
+            if _ACCEPT_TIMEOUT > 0:
+                srv.settimeout(_ACCEPT_TIMEOUT)
+                wait_msg = (
+                    f"rpdb: waiting up to {_ACCEPT_TIMEOUT:.0f}s for mcp "
+                    f"connection on {host}:{port} ..."
+                )
+            else:
+                wait_msg = f"rpdb: waiting for mcp connection on {host}:{port} ..."
+            print(wait_msg, file=sys.__stderr__, flush=True)
+            srv.listen(1)
+            try:
+                self._conn, addr = srv.accept()
+            except _socket.timeout as e:
+                raise SystemExit(
+                    f"rpdb: no mcp client connected within "
+                    f"{_ACCEPT_TIMEOUT:.0f}s. Set "
+                    f"REMOTE_PDB_ACCEPT_TIMEOUT=0 to wait forever, or a "
+                    f"larger value for a longer wait."
+                ) from e
+            # accept() inherits srv's timeout; reset the conn to blocking.
+            self._conn.settimeout(None)
+        finally:
+            srv.close()
         print(f"rpdb: mcp connected from {addr}", file=sys.__stderr__, flush=True)
 
         self._sock_file: IO[str] = self._conn.makefile("r")
@@ -196,7 +242,7 @@ class DualPdb(_pdb.Pdb):
             stdout=cast(IO[str], _TeeOutput(local_out, self._conn)),
         )
 
-    def set_trace(self, frame=None):  # type: ignore[override]
+    def set_trace(self, frame: FrameType | None = None) -> None:  # type: ignore[override]
         if frame is None:
             frame = sys._getframe().f_back
         # Use super() rather than _pdb.Pdb to avoid a NameError if
@@ -207,18 +253,18 @@ class DualPdb(_pdb.Pdb):
         """Close the remote socket before handing off to pdb's quit handler."""
         try:
             self._sock_file.close()
-        except Exception:
+        except OSError:
             pass
         try:
             self._conn.close()
-        except Exception:
+        except OSError:
             pass
         return super().do_quit(arg)
 
     do_q = do_exit = do_quit  # type: ignore[assignment]
 
 
-# ── entry point ───────────────────────────────────────────────────────────────
+# --- entry point -----------------------------------------------------------
 
 _HELP = """\
 usage: rpdb [-c command] ... [-m module | pyfile] [arg] ...

--- a/src/mcp_pdb/rpdb.py
+++ b/src/mcp_pdb/rpdb.py
@@ -1,0 +1,272 @@
+"""
+rpdb.py — remote-pdb wrapper, Python 3.10-compatible.
+
+Usage modes:
+
+  1. Dual session — user keeps a local terminal AND mcp-pdb connects remotely:
+       REMOTE_PDB_PORT=4444 rpdb script.py [args]
+       REMOTE_PDB_PORT=4444 rpdb -m modname  [args]
+
+     What happens:
+       * script starts, rpdb blocks waiting for mcp-pdb to connect
+       * once connected: ALL pdb output goes to both terminal and socket
+       * commands accepted from EITHER terminal stdin OR mcp-pdb (local first)
+
+  2. In-source one-liner (correct frame + all locals visible):
+       from mcp_pdb.rpdb import set_trace; set_trace()
+
+  3. PYTHONBREAKPOINT (zero code changes if code calls breakpoint()):
+       PYTHONBREAKPOINT=mcp_pdb.rpdb.set_trace python script.py
+
+  4. --pdbcls on Python >= 3.11 (remote-only, no local terminal):
+       python -m pdb --pdbcls=mcp_pdb.rpdb:Debugger script.py
+       pytest --pdb --pdbcls=mcp_pdb.rpdb:Debugger
+
+Env vars:  REMOTE_PDB_HOST (default 127.0.0.1)  REMOTE_PDB_PORT (default 4444)
+"""
+import os
+import pdb as _pdb
+import socket as _socket
+import sys
+from typing import IO, cast
+
+from remote_pdb import RemotePdb as _RemotePdb
+
+_HOST = os.environ.get("REMOTE_PDB_HOST", "127.0.0.1")
+_PORT = int(os.environ.get("REMOTE_PDB_PORT", "4444"))
+
+
+# ── modes 2 / 3 ───────────────────────────────────────────────────────────────
+
+def set_trace(host: str = _HOST, port: int = _PORT) -> None:
+    """Drop-in for pdb.set_trace(). Blocks until a client connects."""
+    _RemotePdb(host, port).set_trace(frame=sys._getframe().f_back)
+
+
+# ── mode 4  (Python >= 3.11 --pdbcls, remote-only) ───────────────────────────
+
+class Debugger(_RemotePdb):
+    """Absorbs pdb.Pdb __init__ kwargs; uses REMOTE_PDB_HOST/PORT."""
+    def __init__(self, **_: object) -> None:
+        _RemotePdb.__init__(self, host=_HOST, port=_PORT)
+
+
+# ── mode 1  helpers ───────────────────────────────────────────────────────────
+
+class _TeeOutput:
+    """Write PDB output to both local stdout and remote socket simultaneously."""
+
+    def __init__(self, local: IO[str], conn: _socket.socket) -> None:
+        self._local = local
+        self._conn = conn
+        self._conn_alive = True
+
+    def write(self, data: str) -> None:
+        self._local.write(data)
+        self._local.flush()
+        if self._conn_alive:
+            try:
+                self._conn.sendall(data.encode("utf-8", errors="replace"))
+            except OSError:
+                self._conn_alive = False  # stop trying after first failure
+
+    def flush(self) -> None:
+        self._local.flush()
+
+    def fileno(self) -> int:
+        try:
+            return self._local.fileno()
+        except Exception:
+            return -1
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._local, "encoding", "utf-8")
+
+
+class _SelectStdin:
+    """Read PDB commands from whichever of local stdin / socket is ready first.
+
+    Local stdin is preferred when both are simultaneously ready so the user
+    can always override what mcp-pdb is doing.  Remote commands are echoed to
+    stdout so the user can see them in their terminal.
+    """
+
+    def __init__(self, local: IO[str], sock_file: IO[str]) -> None:
+        self._local = local
+        self._remote = sock_file
+        self._fds: list[IO[str]] = [local, sock_file]
+        # Drain any bytes buffered in stdin before the debugger starts
+        # (e.g. Delete / arrow-key escape sequences left over from the shell).
+        import select as _sel, os as _os
+        try:
+            if _sel.select([local], [], [], 0)[0]:
+                _os.read(local.fileno(), 4096)
+        except Exception:
+            pass
+
+    def readline(self) -> str:
+        # pdb._runscript() clears __main__.__dict__ before starting the
+        # debuggee.  Re-import here so names are always available regardless
+        # of whether this module is __main__ or an installed package.
+        import select as _sel
+        import sys as _sys
+
+        while self._fds:
+            try:
+                # Use a timeout so KeyboardInterrupt (SIGINT) can propagate.
+                # select() with no timeout is auto-restarted by Python 3 after
+                # SIGINT (PEP 475), making Ctrl+C impossible to deliver.
+                ready, _, _ = _sel.select(self._fds, [], [], 0.5)
+            except (ValueError, OSError):
+                # stdin not selectable (e.g. redirected); drop it
+                self._fds = [f for f in self._fds if f is not self._local]
+                continue
+
+            if not ready:
+                continue  # timeout — loop back, allowing pending signals to fire
+
+            # Prefer local stdin if both are ready
+            src = self._local if self._local in ready else ready[0]
+            line = src.readline()
+            if line:
+                if src is self._remote:
+                    # Echo remote commands to local terminal
+                    out = _sys.__stdout__ or _sys.stdout
+                    out.write(line)
+                    out.flush()
+                return line
+
+            # EOF on this source.
+            # If local stdin closed (Ctrl+D), propagate EOF to PDB immediately
+            # rather than continuing to wait on the remote socket.
+            if src is self._local:
+                self._fds = []
+            else:
+                self._fds = [f for f in self._fds if f is not src]
+
+        return ""
+
+    def fileno(self) -> int:
+        try:
+            return self._local.fileno()
+        except Exception:
+            return -1
+
+    @property
+    def encoding(self) -> str:
+        return getattr(self._local, "encoding", "utf-8")
+
+
+# ── mode 1  DualPdb ───────────────────────────────────────────────────────────
+
+class DualPdb(_pdb.Pdb):
+    """PDB that serves both the local terminal and a remote mcp-pdb client.
+
+    On construction this blocks until a TCP client connects, then sets up:
+      - stdout → tee to both local terminal and socket
+      - stdin  → select() across local terminal and socket (local preferred)
+
+    Usage:
+        REMOTE_PDB_PORT=4444 rpdb script.py
+        # In a second window / mcp-pdb:
+        connect_remote_debug(host="127.0.0.1", port=4444)
+    """
+
+    def __init__(self, host: str = _HOST, port: int = _PORT, **_: object) -> None:
+        srv = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+        srv.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, True)
+        srv.bind((host, port))
+        print(f"rpdb: waiting for mcp connection on {host}:{port} ...",
+              file=sys.__stderr__, flush=True)
+        srv.listen(1)
+        self._conn, addr = srv.accept()
+        srv.close()
+        print(f"rpdb: mcp connected from {addr}", file=sys.__stderr__, flush=True)
+
+        self._sock_file: IO[str] = self._conn.makefile("r")
+
+        # sys.__stdin__ / sys.__stdout__ can be None if streams were replaced;
+        # fall back to the live sys.stdin / sys.stdout in that case.
+        local_in:  IO[str] = sys.__stdin__  or sys.stdin
+        local_out: IO[str] = sys.__stdout__ or sys.stdout
+
+        super().__init__(
+            stdin=cast(IO[str],  _SelectStdin(local_in,  self._sock_file)),
+            stdout=cast(IO[str], _TeeOutput(local_out, self._conn)),
+        )
+
+    def set_trace(self, frame=None):  # type: ignore[override]
+        if frame is None:
+            frame = sys._getframe().f_back
+        # Use super() rather than _pdb.Pdb to avoid a NameError if
+        # __main__.__dict__ has been cleared by pdb._runscript().
+        super().set_trace(frame)
+
+    def do_quit(self, arg: str) -> bool | None:  # type: ignore[override]
+        """Close the remote socket before handing off to pdb's quit handler."""
+        try:
+            self._sock_file.close()
+        except Exception:
+            pass
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+        return super().do_quit(arg)
+
+    do_q = do_exit = do_quit  # type: ignore[assignment]
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+_HELP = """\
+usage: rpdb [-c command] ... [-m module | pyfile] [arg] ...
+
+rpdb — dual-session debugger: local terminal + remote mcp-pdb client.
+
+rpdb waits for the mcp-pdb agent (or any TCP client) to connect, then
+starts the script.  All PDB output goes to both the local terminal and
+the remote client.  Commands are accepted from either source; the local
+terminal takes priority.
+
+Examples:
+  REMOTE_PDB_PORT=4444 rpdb script.py [args]
+  REMOTE_PDB_PORT=4444 rpdb -m mymodule [args]
+  REMOTE_PDB_PORT=4444 rpdb -c 'b 42' script.py
+
+Then connect the mcp-pdb agent:
+  connect_remote_debug(host="127.0.0.1", port=4444)
+
+Environment variables:
+  REMOTE_PDB_HOST   Interface to listen on  (default: 127.0.0.1)
+  REMOTE_PDB_PORT   TCP port                (default: 4444)
+
+Flags:
+  -c command        Execute 'command' as if given in .pdbrc
+  -m module         Debug a module (like python -m module)
+  -h, --help        Show this message and exit
+"""
+
+
+def main() -> None:
+    """Console-script entry point for the ``rpdb`` command.
+
+    Patches pdb.Pdb with DualPdb so that pdb.main() (which handles all
+    argument parsing: -m, -c, etc.) instantiates DualPdb.
+    Works on Python 3.10 — no --pdbcls flag needed.
+    """
+    import sys as _sys
+
+    if "-h" in _sys.argv[1:] or "--help" in _sys.argv[1:]:
+        print(_HELP, end="")
+        raise SystemExit(0)
+
+    # Fix the argv[0] so pdb's internal error messages say 'rpdb' not 'pdb.py'
+    _sys.argv[0] = "rpdb"
+    _pdb.Pdb = DualPdb  # type: ignore[misc]
+    _pdb.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -15,6 +15,7 @@ import pytest
 from mcp_pdb.main import (
     find_project_root,
     find_venv_details,
+    get_pdb_output,
     read_socket_output,
     sanitize_arguments,
 )
@@ -353,7 +354,7 @@ class TestSanitizeArguments:
 # Remote PDB helpers
 # ---------------------------------------------------------------------------
 
-def _make_socket_pair():
+def _make_socket_pair() -> tuple[socket.socket, socket.socket]:
     """Return a connected (server_conn, client) socket pair for testing."""
     srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     srv.bind(("127.0.0.1", 0))
@@ -395,7 +396,8 @@ class TestReadSocketOutput:
 
         assert "> /tmp/test.py(1)<module>()" in collected
         assert "-> x = 1" in collected
-        assert "(Pdb)" in collected
+        # rstrip('\r') preserves the trailing space in '(Pdb) '
+        assert any(line.startswith("(Pdb)") for line in collected), collected
 
     def test_emits_prompt_without_newline(self):
         """(Pdb) prompt (no trailing \\n) should be emitted via select timeout."""
@@ -488,6 +490,82 @@ class TestReadSocketOutput:
             assert not line.endswith("\r"), repr(line)
 
 
+@pytest.fixture
+def caveman_toggle():
+    """Yield a callable that sets caveman_mode on the real main module.
+
+    Restores the original value on teardown and drains the shared queue
+    so one test's residue does not leak into the next.  getattr/setattr
+    is used to avoid Pyright complaining that the attribute is unknown
+    on the generic ``ModuleType`` — the global is dynamically assigned
+    via ``globals()[...]`` in the runtime code and static analysis
+    cannot see it.
+    """
+    m = sys.modules["mcp_pdb.main"]
+    original_mode = getattr(m, "caveman_mode")
+    while not m.pdb_output_queue.empty():
+        m.pdb_output_queue.get_nowait()
+
+    def _set(value: bool) -> None:
+        setattr(m, "caveman_mode", value)
+
+    try:
+        yield _set
+    finally:
+        setattr(m, "caveman_mode", original_mode)
+        while not m.pdb_output_queue.empty():
+            m.pdb_output_queue.get_nowait()
+
+
+def _seed_queue(*lines: str) -> None:
+    q = sys.modules["mcp_pdb.main"].pdb_output_queue
+    for line in lines:
+        q.put(line)
+
+
+class TestCavemanModeOutputStripping:
+    """Tests for caveman_mode prompt stripping in get_pdb_output.
+
+    get_pdb_output drains pdb_output_queue and, when caveman_mode is
+    enabled, removes bare '(Pdb)' prompt lines and strips the '(Pdb) '
+    prefix that can appear on the first response line.  These tests
+    directly exercise the transformation by seeding the shared queue.
+    """
+
+    def test_caveman_mode_off_preserves_prompt_lines(self, caveman_toggle):
+        """With caveman_mode=False, output is returned verbatim."""
+        caveman_toggle(False)
+        _seed_queue("-> x = 1", "(Pdb)")
+        out = get_pdb_output(timeout=0.2)
+        assert "-> x = 1" in out
+        assert "(Pdb)" in out
+
+    def test_caveman_mode_on_drops_bare_prompt_lines(self, caveman_toggle):
+        """With caveman_mode=True, a bare '(Pdb)' line is removed."""
+        caveman_toggle(True)
+        _seed_queue("-> x = 1", "(Pdb)")
+        out = get_pdb_output(timeout=0.2)
+        assert "-> x = 1" in out
+        assert "(Pdb)" not in out
+
+    def test_caveman_mode_on_strips_prompt_prefix(self, caveman_toggle):
+        """With caveman_mode=True, '(Pdb) value' becomes 'value'."""
+        caveman_toggle(True)
+        _seed_queue("(Pdb) 42", "(Pdb)")
+        out = get_pdb_output(timeout=0.2)
+        # Prefix stripped from the data line, bare prompt dropped entirely.
+        assert out.splitlines() == ["42"]
+
+    def test_caveman_mode_preserves_non_prompt_lines(self, caveman_toggle):
+        """Lines that merely contain '(Pdb)' in text are not modified."""
+        caveman_toggle(True)
+        # A variable whose repr happens to contain '(Pdb)' mid-line must
+        # not be altered.  Only leading-prefix or bare-line match.
+        _seed_queue("value with (Pdb) inside", "(Pdb)")
+        out = get_pdb_output(timeout=0.2)
+        assert "value with (Pdb) inside" in out
+
+
 class TestRemoteSessionStateIsolation:
     """Verify that remote globals do not bleed into local session globals."""
 
@@ -503,6 +581,5 @@ class TestRemoteSessionStateIsolation:
 
         assert m.remote_mode is False          # type: ignore[attr-defined]
         assert m.remote_socket is None         # type: ignore[attr-defined]
-        assert m.remote_socket_file is None    # type: ignore[attr-defined]
         assert m.remote_host == ""             # type: ignore[attr-defined]
         assert m.remote_port == 0              # type: ignore[attr-defined]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,14 +1,23 @@
 """Tests for helper functions in mcp_pdb.main."""
 
 import os
+import queue
+import socket
 import sys
 import tempfile
+import threading
+import time  # noqa: F401 – used in test_emits_prompt_without_newline
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from mcp_pdb.main import find_project_root, find_venv_details, sanitize_arguments
+from mcp_pdb.main import (
+    find_project_root,
+    find_venv_details,
+    read_socket_output,
+    sanitize_arguments,
+)
 
 
 class TestFindProjectRoot:
@@ -338,3 +347,162 @@ class TestSanitizeArguments:
         """Should handle arguments with equals signs."""
         result = sanitize_arguments("--key=value --other=123")
         assert result == ["--key=value", "--other=123"]
+
+
+# ---------------------------------------------------------------------------
+# Remote PDB helpers
+# ---------------------------------------------------------------------------
+
+def _make_socket_pair():
+    """Return a connected (server_conn, client) socket pair for testing."""
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(("127.0.0.1", port))
+
+    server_conn, _ = srv.accept()
+    srv.close()
+    return server_conn, client
+
+
+class TestReadSocketOutput:
+    """Tests for the read_socket_output helper (recv-based, raw socket)."""
+
+    def test_reads_lines_into_queue(self):
+        """Should decode newline-terminated lines and put them in the queue."""
+        server_conn, client = _make_socket_pair()
+        out_q = queue.Queue()
+
+        t = threading.Thread(
+            target=read_socket_output,
+            args=(client, out_q),
+            daemon=True,
+        )
+        t.start()
+
+        server_conn.sendall(b"> /tmp/test.py(1)<module>()\n")
+        server_conn.sendall(b"-> x = 1\n")
+        server_conn.sendall(b"(Pdb) \n")
+        server_conn.close()
+
+        t.join(timeout=2.0)
+        collected = []
+        while not out_q.empty():
+            collected.append(out_q.get_nowait())
+
+        assert "> /tmp/test.py(1)<module>()" in collected
+        assert "-> x = 1" in collected
+        assert "(Pdb)" in collected
+
+    def test_emits_prompt_without_newline(self):
+        """(Pdb) prompt (no trailing \\n) should be emitted via select timeout."""
+        server_conn, client = _make_socket_pair()
+        out_q = queue.Queue()
+
+        t = threading.Thread(
+            target=read_socket_output,
+            args=(client, out_q),
+            daemon=True,
+        )
+        t.start()
+
+        server_conn.sendall(b"> /tmp/test.py(1)<module>()\n")
+        server_conn.sendall(b"-> x = 1\n")
+        # Send prompt WITHOUT trailing newline — the critical case
+        server_conn.sendall(b"(Pdb) ")
+        time.sleep(0.15)  # longer than the 50 ms select timeout in the reader
+        server_conn.close()
+
+        t.join(timeout=2.0)
+        collected = []
+        while not out_q.empty():
+            collected.append(out_q.get_nowait())
+
+        assert any("(Pdb)" in line for line in collected), collected
+
+    def test_handles_unicode_in_output(self):
+        """Should handle non-ASCII characters with 'replace' error mode."""
+        server_conn, client = _make_socket_pair()
+        out_q = queue.Queue()
+
+        t = threading.Thread(
+            target=read_socket_output,
+            args=(client, out_q),
+            daemon=True,
+        )
+        t.start()
+
+        server_conn.sendall("résultat = 42\n".encode("utf-8"))
+        server_conn.sendall(b"bad \xff byte\n")
+        server_conn.close()
+
+        t.join(timeout=2.0)
+        collected = []
+        while not out_q.empty():
+            collected.append(out_q.get_nowait())
+
+        assert any("sultat" in line for line in collected), collected
+        assert any("bad" in line for line in collected), collected
+
+    def test_stops_on_eof(self):
+        """Thread should exit cleanly when the socket is closed."""
+        server_conn, client = _make_socket_pair()
+        out_q = queue.Queue()
+
+        t = threading.Thread(
+            target=read_socket_output,
+            args=(client, out_q),
+            daemon=True,
+        )
+        t.start()
+
+        server_conn.close()
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "Reader thread should have exited on EOF"
+
+    def test_rstrips_trailing_cr(self):
+        """Lines sent with \\r\\n endings should have the \\r stripped."""
+        server_conn, client = _make_socket_pair()
+        out_q = queue.Queue()
+
+        t = threading.Thread(
+            target=read_socket_output,
+            args=(client, out_q),
+            daemon=True,
+        )
+        t.start()
+
+        server_conn.sendall(b"(Pdb) \r\n")
+        server_conn.close()
+
+        t.join(timeout=2.0)
+        collected = []
+        while not out_q.empty():
+            collected.append(out_q.get_nowait())
+
+        for line in collected:
+            assert not line.endswith("\n"), repr(line)
+            assert not line.endswith("\r"), repr(line)
+
+
+class TestRemoteSessionStateIsolation:
+    """Verify that remote globals do not bleed into local session globals."""
+
+    def test_remote_globals_default_values(self):
+        """Remote-session globals should start at their documented defaults."""
+        import sys
+
+        # mcp_pdb/__init__.py shadows 'mcp_pdb.main' attribute with the
+        # main() function, so we retrieve the actual module from sys.modules
+        # (it is guaranteed to be present because other imports in this file
+        # already loaded it).
+        m = sys.modules["mcp_pdb.main"]
+
+        assert m.remote_mode is False          # type: ignore[attr-defined]
+        assert m.remote_socket is None         # type: ignore[attr-defined]
+        assert m.remote_socket_file is None    # type: ignore[attr-defined]
+        assert m.remote_host == ""             # type: ignore[attr-defined]
+        assert m.remote_port == 0              # type: ignore[attr-defined]

--- a/uv.lock
+++ b/uv.lock
@@ -124,6 +124,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -168,8 +177,16 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "mcp", extras = ["cli"], specifier = ">=1.6.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
 
 [[package]]
 name = "mdurl"
@@ -178,6 +195,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -305,6 +340,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -368,6 +421,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102, upload-time = "2025-03-08T10:55:34.504Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995, upload-time = "2025-03-08T10:55:32.662Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -175,6 +175,7 @@ version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
+    { name = "remote-pdb" },
 ]
 
 [package.dev-dependencies]
@@ -183,7 +184,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mcp", extras = ["cli"], specifier = ">=1.6.0" }]
+requires-dist = [
+    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "remote-pdb", specifier = ">=2.1.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0.0" }]
@@ -364,6 +368,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
+name = "remote-pdb"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b5/4944cac06fd9fc4a2e168313ec220aa25ed96ce83947b63eea5b4045b22d/remote-pdb-2.1.0.tar.gz", hash = "sha256:2d70c6f41e0eabf0165e8f1be58f82aa7a605aaeab8f2aefeb9ce246431091c1", size = 22295, upload-time = "2020-07-24T13:31:32.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/c5/d208c66344bb785d800adb61aef512290d3473052b9e7697890f0547aff2/remote_pdb-2.1.0-py2.py3-none-any.whl", hash = "sha256:94f73a92ac1248cf16189211011f97096bdada8a7baac8c79372663bbb57b5d0", size = 6304, upload-time = "2020-07-24T13:31:31.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

- Add `connect_remote_debug()` MCP tool — connects to any Python process               
  running PDB over a TCP socket, making all existing tools work transparently
  over the network                                                                     
- Add `rpdb` CLI command — a `python -m pdb` drop-in that mirrors all output
  to both the local terminal and the MCP agent simultaneously                          
- Fix the remote socket reader so the `(Pdb)` prompt is delivered without
  blocking on its missing newline
- Add `caveman_mode` flag to control output verbosity per session (intermediate between https://github.com/markomanninen/mcp-debugpy and very verbose output)
- 32 tests, 0 Pyright errors                                                           
 
### Motivation                                                                         
                
The previous `start_debug` tool only worked on scripts the agent could launch          
locally. This blocked two real use cases:
                                                                                       
1. **Long-running processes** — a training loop, a server, a complex pipeline          
   already in progress; you can't restart it under a fresh pdb subprocess.
2. **Collaborative debugging** — the developer wants to stay in their terminal         
   while the AI agent assists: sets breakpoints, inspects variables, steps
   through code on request.                                                            
                                                                                       
A secondary concern was token cost: the original output sent ~300 tokens per           
navigation step and 90+ attribute names on every variable inspection,                  
regardless of whether the caller needed them.                                          
                                                                                       
### What changed                                                                       
                                                                                       
**`mcp_pdb/main.py`**
- New `connect_remote_debug(host, port, timeout, caveman_mode)` MCP tool.
  Retries the connection until `timeout` seconds, then waits for the initial           
  `(Pdb)` prompt.  All existing tools (`send_pdb_command`, `set_breakpoint`,           
  `examine_variable`, etc.) work unchanged once connected.                             
- `send_to_pdb()` refactored to route through either subprocess stdin (local)          
  or `socket.sendall()` (remote) based on a `remote_mode` flag.                        
- `read_socket_output()` rewritten to use `recv()` + a 50 ms `select()` timeout        
  instead of `readline()`. This is the key fix: `readline()` blocks forever on         
  the `(Pdb)` prompt because it has no trailing newline; `recv()` + timeout            
  emits the partial buffer immediately.                                                
- `end_debug()`, `restart_debug()`, `get_debug_status()` all handle remote             
  sessions correctly (socket close, reconnect, remote host/port in status).            
- `caveman_mode` session flag (see below).
                                                                                       
**`mcp_pdb/rpdb.py`** (new)
- `DualPdb` — `pdb.Pdb` subclass that blocks on TCP `accept()` before starting,        
  then tees all PDB output to both `sys.stdout` and the socket (`_TeeOutput`),         
  and reads commands from whichever of local stdin or the socket is ready first        
  (`_SelectStdin`, local preferred).                                                   
- `set_trace()` / `Debugger` — drop-in replacements for inline use and                 
  `--pdbcls` (Python ≥ 3.11).                                                          
- `main()` — patching entry point; works on Python 3.10 without `--pdbcls`.            
- Handles `pdb._runscript()` clearing `__main__.__dict__`: re-imports `select`         
  and `sys` inside `readline()` so names are always available.                         
- `do_quit()` closes the remote socket on session end.
- `rpdb --help` shows rpdb-specific usage instead of the raw pdb.py text.              
                                                                                       
**`caveman_mode` flag**                                                                
                                                                                       
Both `start_debug()` and `connect_remote_debug()` accept `caveman_mode=False`          
(default = verbose, preserves original behaviour exactly):
                                                                                       
| | `caveman_mode=False` (default) | `caveman_mode=True` |
|--|--|--|                                                                             
| `(Pdb)` prompts | preserved in output | stripped |
| After `n/s/c/r/unt` | 11-line source window appended | location line only |          
| `examine_variable` | full block: value, pp, type, dir() | `Value: …\nType: …` |      
| `get_debug_status` | `l .` source listing | `w` stack trace |                        
                                                                                       
Typical savings with `caveman_mode=True`: ~80% fewer tokens per navigation             
step, >90% fewer tokens for variable inspection.                                       
                                                                                       
### Usage       
                                                                                       
```bash         
# Start a script with both terminal and remote access:
REMOTE_PDB_PORT=4444 rpdb script.py                                                    
 
# Then in mcp-pdb (verbose, default):                                                  
connect_remote_debug(host="127.0.0.1", port=4444)
                                                                                       
# Or compact output for token-constrained agents:                                      
connect_remote_debug(host="127.0.0.1", port=4444, caveman_mode=True)                   
start_debug("script.py", caveman_mode=True)                                            
                
All PDB output appears in both terminal and agent. Either side can send                
commands; local terminal takes priority.
                                                                                       
Test plan       
                                                                                       
- TestReadSocketOutput — loopback socket pair, verifies line decoding,                 
unicode replacement, EOF, \r\n stripping, and prompt emission without \n
- TestRemoteSessionStateIsolation — remote globals at documented defaults              
- Manually tested end-to-end: rpdb models-ti.py, connected mcp-pdb,                    
stepped through code, inspected variables, continued to completion                     
- Manually verified caveman_mode=True vs caveman_mode=False output                     
differences for n, examine_variable, and get_debug_status                              
